### PR TITLE
Remove output for 'nativejs' annotations on functions for issue #160

### DIFF
--- a/src/main/java/com/redhat/ceylon/compiler/js/GenerateJsVisitor.java
+++ b/src/main/java/com/redhat/ceylon/compiler/js/GenerateJsVisitor.java
@@ -1051,9 +1051,10 @@ public class GenerateJsVisitor extends Visitor
 
     @Override
     public void visit(MethodDefinition that) {
+        Method d = that.getDeclarationModel();
         //Don't even bother with nodes that have errors
         if (that.getErrors() != null && !that.getErrors().isEmpty()) return;
-        if (!(prototypeStyle && that.getDeclarationModel().isClassOrInterfaceMember())) {
+        if (!((prototypeStyle && that.getDeclarationModel().isClassOrInterfaceMember()) || isNative(d))) {
             comment(that);
             methodDefinition(that);
         }


### PR DESCRIPTION
Add ability to add 'nativejs' annotation to functions for use on functions such as 'require' when running in node issue #160
