### PR TITLE
Fix typo in InitializationError message

### DIFF
--- a/src/main/java/com/redhat/ceylon/compiler/js/GenerateJsVisitor.java
+++ b/src/main/java/com/redhat/ceylon/compiler/js/GenerateJsVisitor.java
@@ -1590,7 +1590,7 @@ public class GenerateJsVisitor extends Visitor {
         //TODO we can later optimize this, to replace this getter with the plain one
         //once the value has been defined
         out("if(", privname, "===undefined)throw ", getClAlias(),
-                "InitializationError('Attempt to read unitialized attribute «", pubname, "»');");
+                "InitializationError('Attempt to read uninitialized attribute «", pubname, "»');");
     }
     void generateImmutableAttributeReassignmentCheck(FunctionOrValue decl, String privname, String pubname) {
         if (decl.isLate() && !decl.isVariable()) {


### PR DESCRIPTION
Triggered in the web ide with this code:

``` ceylon
class Child() {
    shared late Parent parent;
    shared void doSomething() {
        print("Hello, " + parent.string);
    }
}

class Parent() {
    shared Child child = Child();
    //child.parent = this; //ok, since parent is late
    child.doSomething();
}
value p = Parent();
```
